### PR TITLE
Fix read to not hang after disconnecting from serial

### DIFF
--- a/mecode/printer.py
+++ b/mecode/printer.py
@@ -256,7 +256,7 @@ class Printer(object):
             return
         self.printing = True
         self.stop_printing = False
-        self._print_thread = Thread(target=self._print_worker, name='Print')
+        self._print_thread = Thread(target=self._print_worker_entrypoint, name='Print')
         self._print_thread.setDaemon(True)
         self._print_thread.start()
         logger.debug('print_thread started')
@@ -271,10 +271,22 @@ class Printer(object):
         if self._read_thread is not None and self._read_thread.is_alive():
             return
         self.stop_reading = False
-        self._read_thread = Thread(target=self._read_worker, name='Read')
+        self._read_thread = Thread(target=self._read_worker_entrypoint, name='Read')
         self._read_thread.setDaemon(True)
         self._read_thread.start()
         logger.debug('read_thread started')
+
+    def _print_worker_entrypoint(self):
+        try:
+            self._print_worker()
+        except Exception as e:
+            logger.exception("Exception running print worker: " + str(e))
+
+    def _read_worker_entrypoint(self):
+        try:
+            self._read_worker()
+        except Exception as e:
+            logger.exception("Exception running read worker: " + str(e))
 
     def _print_worker(self):
         """ This method is spawned in the print thread. It loops over every line

--- a/mecode/tests/test_printer.py
+++ b/mecode/tests/test_printer.py
@@ -128,7 +128,12 @@ class TestPrinter(unittest.TestCase):
         expected = 'N2 G90*18\n'
         self.assertEqual(line, expected)
 
-    def test_get_response(self):
+    def test_get_response_no_threads_running(self):
+        with self.assertRaises(RuntimeError):
+            self.p.get_response('test')
+
+    def test_get_response_timeout(self):
+        self.p._is_read_thread_running = lambda: True
         resp = self.p.get_response('test', timeout=0.2)
         expected = ''
         # We expect to get a blank response when the timeout is hit.


### PR DESCRIPTION
If you read from serial in one thread and disconnect in another thread, the reading thread will hang.  This pull request changes it so that the reading thread raises an exception.