### PR TITLE
Use typical OS-specific serial settings by default

### DIFF
--- a/mecode/devices/base_serial_device.py
+++ b/mecode/devices/base_serial_device.py
@@ -1,10 +1,17 @@
+import platform
 import serial
 
 
 class BaseSerialDevice(object):
 
-    def __init__(self, comport='COM5', baud=115200):
-        self.comport = comport
+    def __init__(self, comport=None, baud=115200):
+        if comport is None:
+            if 'Windows' in platform.system():
+                self.comport = 'COM5'
+            else:
+                self.comport = '/dev/ttyUSB0'
+        else:
+            self.comport = comport
         self.baud = baud
         self.connect()
 

--- a/mecode/devices/efd_pressure_box.py
+++ b/mecode/devices/efd_pressure_box.py
@@ -1,3 +1,4 @@
+import platform
 import serial
 
 STX = '\x02'  #Packet Start
@@ -10,8 +11,14 @@ EOT = '\x04'  #End Of Transmission
 
 class EFDPressureBox(object):
     
-    def __init__(self, comport='COM4'):
-        self.comport = comport
+    def __init__(self, comport=None):
+        if comport is None:
+            if 'Windows' in platform.system():
+                self.comport = 'COM4'
+            else:
+                self.comport = '/dev/ttyUSB0'
+        else:
+            self.comport = comport
         self.connect()
         
     def connect(self):


### PR DESCRIPTION
Still somewhat hard-coded but this simplifies instantiation a bit, at least for the (very few) applications I've seen so far..
