### PR TITLE
Abs fix

### DIFF
--- a/mecode/matrix.py
+++ b/mecode/matrix.py
@@ -52,7 +52,7 @@ class GMatrix(G):
     # Matrix manipulation #####################################################        
     def _matrix_setup(self):
         " Create our matrix stack. "
-        self.matrix_stack = [np.identity(2)]
+        self.matrix_stack = [np.matrix([[1.0, 0], [0.0, 1.0]])]
 
     def push_matrix(self):
         " Push a copy of our current transformation matrix. "
@@ -90,12 +90,12 @@ class GMatrix(G):
         (x,y,z) = self._matrix_transform(length, 0, 0)
         return math.sqrt(x**2 + y**2 + z**2)
 
-    # abs_move ends up invoking move, which means that
-    # we don't need to do a matrix transform here.
     def abs_move(self, x=None, y=None, z=None, **kwargs):
         if x is None: x = self.current_position['x']
         if y is None: y = self.current_position['y']
         if z is None: z = self.current_position['z']
+        # abs_move ends up invoking move, which means that
+        # we don't need to do a matrix transform here.
         super(GMatrix, self).abs_move(x,y,z, **kwargs)
 
     def move(self, x=None, y=None, z=None, **kwargs):
@@ -121,7 +121,7 @@ class GMatrix(G):
         if y is None: y = 0.0
 
         matrix = self.matrix_stack[-1]
-        transform = matrix.T * np.matrix([x, y]).T
+        transform = matrix.getI() * np.matrix([x, y]).T
         
         return { 'x':transform.item(0),
                  'y':transform.item(1),

--- a/mecode/matrix.py
+++ b/mecode/matrix.py
@@ -90,11 +90,12 @@ class GMatrix(G):
         (x,y,z) = self._matrix_transform(length, 0, 0)
         return math.sqrt(x**2 + y**2 + z**2)
 
+    # abs_move ends up invoking move, which means that
+    # we don't need to do a matrix transform here.
     def abs_move(self, x=None, y=None, z=None, **kwargs):
         if x is None: x = self.current_position['x']
         if y is None: y = self.current_position['y']
         if z is None: z = self.current_position['z']
-        (x,y,z) = self._matrix_transform(x,y,z)
         super(GMatrix, self).abs_move(x,y,z, **kwargs)
 
     def move(self, x=None, y=None, z=None, **kwargs):

--- a/mecode/tests/test_matrix.py
+++ b/mecode/tests/test_matrix.py
@@ -2,6 +2,7 @@
 
 from os.path import abspath, dirname
 import unittest
+import sys
 import math
 
 HERE = dirname(abspath(__file__))
@@ -77,24 +78,16 @@ class TestGMatrix(TestGFixture):
 
     def test_abs_move_and_rotate(self):
         self.g.abs_move(x=5.0)
-        self.assertEqual(self.g.current_position['x'], 5.0)
-        self.assertEqual(self.g.current_position['y'], 0.0)
-        self.assertEqual(self.g.current_position['z'], 0.0)
+        self.assert_almost_position({'x' : 5.0, 'y':0, 'z':0})
         self.g.rotate(math.pi)
-        self.assertAlmostEqual(self.g.current_position['x'], -5.0)
-        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
-        self.assertAlmostEqual(self.g.current_position['z'], 0.0)
+        self.assert_almost_position({'x' : -5.0, 'y':0, 'z':0})
 
-    def test_abs_zmove(self):
+    def test_abs_zmove_with_flip(self):
         self.g.rotate(math.pi)
         self.g.abs_move(x=1)
-        self.assertAlmostEqual(self.g.current_position['x'], 1.0)
-        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
-        self.assertAlmostEqual(self.g.current_position['z'], 0.0)
+        self.assert_almost_position({'x': 1.0, 'y': 0, 'z': 0})
         self.g.abs_move(z=2)
-        self.assertAlmostEqual(self.g.current_position['x'], 1.0)
-        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
-        self.assertAlmostEqual(self.g.current_position['z'], 2.0)
+        self.assert_almost_position({'x': 1.0, 'y': 0, 'z': 2})        
 
         self.expect_cmd("""
         G90  
@@ -105,6 +98,31 @@ class TestGMatrix(TestGFixture):
         G91
         """)
         self.assert_output()
+
+    def test_abs_zmove_with_rotate(self):
+        self.g.rotate(math.pi/2.0)
+        self.g.abs_move(x=1)
+        self.assert_almost_position({'x': 1.0, 'y': 0, 'z': 0})
+        self.g.abs_move(z=2)
+        self.assert_almost_position({'x': 1.0, 'y': 0, 'z': 2})        
+        self.expect_cmd("""
+        G90  
+        G1 X0.000000 Y1.000000 Z0.000000
+        G91
+        G90 
+        G1 X0.000000 Y1.000000 Z2.000000
+        G91
+        """)
+        self.assert_output()
+
+    def test_scale_and_abs_move(self):
+        self.g.abs_move(x=1)
+        self.g.scale(2.0)
+        self.assert_almost_position({'x': .5, 'y': 0, 'z': 0})
+        self.g.abs_move()
+        self.assert_almost_position({'x': .5, 'y': 0, 'z': 0})
+        self.g.abs_move(z=3)
+        self.assert_almost_position({'x': .5, 'y': 0, 'z': 3})
 
     def test_arc(self):
         self.g.rotate(math.pi/2)

--- a/mecode/tests/test_matrix.py
+++ b/mecode/tests/test_matrix.py
@@ -75,6 +75,37 @@ class TestGMatrix(TestGFixture):
         self.g.pop_matrix()
         self.assert_output()
 
+    def test_abs_move_and_rotate(self):
+        self.g.abs_move(x=5.0)
+        self.assertEqual(self.g.current_position['x'], 5.0)
+        self.assertEqual(self.g.current_position['y'], 0.0)
+        self.assertEqual(self.g.current_position['z'], 0.0)
+        self.g.rotate(math.pi)
+        self.assertAlmostEqual(self.g.current_position['x'], -5.0)
+        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
+        self.assertAlmostEqual(self.g.current_position['z'], 0.0)
+
+    def test_abs_zmove(self):
+        self.g.rotate(math.pi)
+        self.g.abs_move(x=1)
+        self.assertAlmostEqual(self.g.current_position['x'], 1.0)
+        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
+        self.assertAlmostEqual(self.g.current_position['z'], 0.0)
+        self.g.abs_move(z=2)
+        self.assertAlmostEqual(self.g.current_position['x'], 1.0)
+        self.assertAlmostEqual(self.g.current_position['y'], 0.0)
+        self.assertAlmostEqual(self.g.current_position['z'], 2.0)
+
+        self.expect_cmd("""
+        G90  
+        G1 X-1.000000 Y0.000000 Z0.000000
+        G91
+        G90 
+        G1 X-1.000000 Y0.000000 Z2.000000
+        G91
+        """)
+        self.assert_output()
+
     def test_arc(self):
         self.g.rotate(math.pi/2)
         self.g.arc(x=10, y=0)


### PR DESCRIPTION
There is a bug in my original mecode method to get back the current position, and for doing absolute moves.

The absolute moves were being transformed twice, which is bad.

The the other problem was that the override for current_position used the transpose of the matrix instead of the inverse. This manages to work out fine for rotations, but does not work for scaling.