### PR TITLE
Update arcs for reflection.

### DIFF
--- a/mecode/matrix.py
+++ b/mecode/matrix.py
@@ -136,6 +136,13 @@ class GMatrix(G):
         (x,y,z) = self._matrix_transform(x,y,z)
         super(GMatrix, self).move(x,y,z, **kwargs)
 
+    def _arc_direction_transform(self, direction):
+        if np.linalg.det(self.matrix_stack[-1]) < 0:
+            direction_reverse = { 'CW' : 'CCW',
+                                  'CCW' : 'CW' }
+            return direction_reverse[direction]
+        return direction
+
     def arc(self, x=None, y=None, z=None, direction='CW', radius='auto',
             helix_dim=None, helix_len=0, **kwargs):
         (x_prime,y_prime,z_prime) = self._matrix_transform(x,y,z)
@@ -143,6 +150,7 @@ class GMatrix(G):
         if y is None: y_prime = None
         if z is None: z_prime = None
         if helix_len: helix_len = self._matrix_transform_length(helix_len)
+        direction = self._arc_direction_transform(direction)
         super(GMatrix, self).arc(x=x_prime,y=y_prime,z=z_prime,direction=direction,radius=radius,
                                  helix_dim=helix_dim, helix_len=helix_len,
                                  **kwargs)

--- a/mecode/tests/test_matrix.py
+++ b/mecode/tests/test_matrix.py
@@ -134,6 +134,17 @@ class TestGMatrix(TestGFixture):
         self.assert_output()        
         self.assert_almost_position({'x': 10, 'y': 0, 'z': 0})
 
+    def test_arc_reflect(self):
+        self.g.reflect(0.0)
+        self.g.arc(x=10,y=0)
+        # Without the reflect this would be a G2.
+        self.expect_cmd("""
+        G17 ;XY plane
+        G3 X10.000000 Y0.000000 R5.000000
+        """)
+        self.assert_output()
+        self.assert_almost_position({'x': 10, 'y': 0, 'z': 0})
+
     def test_current_position(self):
         self.g.push_matrix()
         self.g.move(5, 0)


### PR DESCRIPTION
After reflection, the orientation of an arc needs to be flipped -
clockwise becomes counter-clockwise, and counter-clockwise becomes
clockwise.