### PR TITLE
Fix Python 2 / Python 3.7 compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ instantiating the `G` object.
 g = G(outfile='path/to/file.gcode', print_lines=False)
 ```
 
-*NOTE:* `g.teardown()` must be called after all commands are executed if you
-are writing to a file. This can be accomplished automatically by using G as
+*NOTE:* When using the option direct_write=True or when writing to a file, 
+`g.teardown()` must be called after all commands are executed. If you
+are writing to a file, this can be accomplished automatically by using G as
 a context manager like so:
 
 ```python
@@ -55,6 +56,30 @@ g.view()
 
 The graphics backend can be specified when calling the `view()` method, e.g. `g.view('matplotlib')`.
 `mayavi` is the default graphics backend.
+
+Direct control via serial communication
+---------------------------------------
+
+With the option `direct_write=True`, a serial connection to the controlled device 
+is established via USB serial at a virtual COM port of the computer and the 
+g-code commands are sent directly to the connected device using a serial 
+communication protocol:
+
+```python
+import mecode
+g = mecode.G(
+    direct_write=True, 
+    direct_write_mode="serial", 
+    printer_port="/dev/tty.usbmodem1411", 
+    baudrate=115200
+)  # Under MS Windows, use printer_port="COMx" where x has to be replaced by the port number of the virtual COM port the device is connected to according to the device manager.
+g.write("M302 S0")  # send g-Code. Here: allow cold extrusion. Danger: Make sure extruder is clean without filament inserted 
+g.absolute()  # Absolute positioning mode
+g.move(x=10, y=10, z=10, F=500)  # move 10mm in x and 10mm in y and 10mm in z at a feedrate of 500 mm/min
+g.retract(10)  # Move extruder motor
+g.write("M400")  # IMPORTANT! wait until execution of all commands is finished
+g.teardown()  # Disconnect (close serial connection)
+```
 
 All GCode Methods
 -----------------

--- a/mecode/main.py
+++ b/mecode/main.py
@@ -28,8 +28,17 @@ instantiating the `G` object. ::
 
     g = G(outfile='path/to/file.gcode', print_lines=False)
 
-*NOTE:* `g.teardown()` must be called after all commands are executed if you
-are writing to a file.
+*NOTE:* When using the option direct_write=True or when writing to a file, 
+`g.teardown()` must be called after all commands are executed. If you
+are writing to a file, this can be accomplished automatically by using G as
+a context manager like so:
+
+```python
+with G(outfile='file.gcode') as g:
+    g.move(10)
+```
+
+When the `with` block is exited, `g.teardown()` will be automatically called.
 
 The resulting toolpath can be visualized in 3D using the `mayavi` package with
 the `view()` method ::

--- a/mecode/tests/test_printer.py
+++ b/mecode/tests/test_printer.py
@@ -13,6 +13,37 @@ import serial
 
 from mecode.printer import Printer
 
+# for python 2/3 compatibility
+try:
+    reduce
+except NameError:
+    # In python 3, reduce is no longer imported by default.
+    from functools import reduce
+
+try:
+    isinstance("", basestring)
+
+    def is_str(s):
+        return isinstance(s, basestring)
+
+    def encode2To3(s):
+        return s
+
+    def decode2To3(s):
+        return s
+
+except NameError:
+
+    def is_str(s):
+        return isinstance(s, str)
+
+    def encode2To3(s):
+        return bytes(s, 'UTF-8')
+
+    def decode2To3(s):
+        return s.decode('UTF-8')
+
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -21,7 +52,7 @@ class TestPrinter(unittest.TestCase):
     def setUp(self):
         self.p = Printer()
         self.p.s = Mock(spec=serial.Serial(), name='MockSerial')
-        self.p.s.readline.return_value = 'ok\n'
+        self.p.s.readline.return_value = encode2To3('ok\n')
         self.p.s.timeout = 1
         self.p.s.writeTimeout = 1
 
@@ -57,13 +88,13 @@ class TestPrinter(unittest.TestCase):
         self.p.sendline(testline)
         while len(self.p.sentlines) == 0:
             sleep(0.01)
-        self.p.s.write.assert_called_with('N1 no new line*44\n')
+        self.p.s.write.assert_called_with(encode2To3('N1 no new line*44\n'))
 
         testline = 'with new line\n'
         self.p.sendline(testline)
         while len(self.p.sentlines) == 1:
             sleep(0.01)
-        self.p.s.write.assert_called_with('N2 with new line*44\n')
+        self.p.s.write.assert_called_with(encode2To3('N2 with new line*44\n'))
 
     def test_start(self):
         self.assertIsNone(self.p._read_thread)


### PR DESCRIPTION
Fixes Python2 / 3 compatibility with direct_write=True and gives example in the readme. Clearify
documentation regarding importance of g.teardown(). See issue #66 and issue #67 